### PR TITLE
Remove AUDIO_DEVICE_BIT_IN for mako again

### DIFF
--- a/src/droid/droid-util.c
+++ b/src/droid/droid-util.c
@@ -964,7 +964,9 @@ static void add_i_ports(pa_droid_mapping *am) {
         if (devices & cur_device) {
 
 #if DROID_HAL >= 2
+#ifndef DROID_DEVICE_MAKO
             cur_device |= AUDIO_DEVICE_BIT_IN;
+#endif            
 #endif
 
             pa_assert_se(pa_droid_input_port_name(cur_device, &name));


### PR DESCRIPTION
To see if this fixes the issues on Mako with PA not working anymore after upgrade.
